### PR TITLE
Troca verificacoes img[alt=""]

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Esta tabela mostra casos de incumprimento do regulamento:
 | https://www.inventarios.pt | Obriga à utilização de JAVA ou software que só existe para MAC e Windows | [manual de instalação](https://www.inventarios.pt/documentos/manual_instalacao_gosign_v4.pdf) | 2020/08/08 ||
 | http://www.turismodeportugal.pt/ | Informação apenas em XLSX | [página com vários links para informação apenas em XLSX](http://business.turismodeportugal.pt/pt/Planear_Iniciar/Licenciamento_Registo_da_Atividade/Empreendimentos_Turisticos/Paginas/classificacao-et.aspx) | 2020/08/08 ||
 | https://www.norte2020.pt/ | Informação apenas em XLSX | [página com documento apenas em XLSX](https://www.norte2020.pt/investimento-municipal) | 2020/08/08 | 2019/10/29 |
-| https://siac.vet/ | Acessibilidade | [página não cumpre com WCAG 2.0](https://siac.vet/) | 2020/08/08 ||
+| https://siac.vet/ | Acessibilidade | [página não cumpre com WCAG 2.0](https://siac.vet/) | 2020/08/18 ||
 | http://www.estradas.pt | Flash | [página com conteúdo Flash para alguns browsers](http://www.estradas.pt/index) | 2020/08/08 | 2019/11/06 |
 | https://www.sef.pt/ | Documentos em .doc | [Documentos em .doc no final da página (anunciados como .pdf)](https://www.sef.pt/pt/pages/conteudo-detalhe.aspx?nID=73) | 2020/08/08 ||
 | https://online.dgo.pt/ | versão insegura de TLS | [protocolo utilizado para https é TLS 1.0](http://online.dgo.pt/) | 2020/08/08 ||

--- a/scripts/05-governo.sh
+++ b/scripts/05-governo.sh
@@ -6,11 +6,9 @@
 
 # While we don't have a validator on request, let's find out if a known violation still exists
 ## several images without an alt attribute:
-## if the alt attribute exists but is empty, it's still an WCAG violation...
 ## Empty links are also WCAG violations
 
 fails="$(wget https://www.portugal.gov.pt -o /dev/null -O - | grep "<img" |grep -v alt|wc -l)"
-fails=$((fails + $(wget https://www.portugal.gov.pt -o /dev/null -O - | grep "<img" |grep -c alt=\'\')))
 fails=$((fails + $(wget https://www.portugal.gov.pt -o /dev/null -O - | hxnormalize -x -l 10000|hxselect a -c -s'\n'|grep -c ^$)))
 
 if [ "$fails" -eq "0" ]; then

--- a/scripts/38-siac.sh
+++ b/scripts/38-siac.sh
@@ -1,10 +1,28 @@
 #!/bin/bash
 
-fails="$(wget https://www.siac.vet -o /dev/null -O - | grep "<img" |grep alt=\"\"|wc -l)"
+# This would be easier if hxremove 7.9 would have been released already.
+# What we're looking for is <a> without text or with images only whose alt text
+# is empty.
+#
+# We wouldn't need the while/hxselect mess if we could do hxremove img[alt=""],
+# but this segfaults in 7.8.
+#
+# What I'm doing here is:
+# - cleaning up newlines
+# - fetching every link
+# - appending the alt text of any images in <a> bodies
+# - remove the images from <a> bodies
+# - if what's left has any text, it should be ok
 
-if [ "$fails" -eq "0" ]; then
-	echo "siac: incumprimento pode já não existir (1)";
-else
+if curl -L https://www.siac.vet |
+		hxclean |
+		tr '\n' ' ' |
+		hxselect -c -s '\n' 'a[href="https://siac.vet"]' |
+		while IFS= read line; do
+			echo "$line $(echo "$line" | hxselect -c 'img::attr(alt)')";
+		done |
+		hxremove 'img' |
+		grep "^\s*$" > /dev/null; then
 	echo "siac: Incumprimento mantém-se, a actualizar o README (faça um git diff, valide, e commit!)";
 	while IFS='' read -r line || [[ -n "$line" ]]; do
 		test "$(echo "$line"|grep -v -c "siac")" -eq "1" \
@@ -12,4 +30,6 @@ else
 			|| (h=$(echo "$line"|cut -d\| -f1-4); t=$(echo "$line"|cut -d\| -f6-); echo "$h| $(date +%Y/%m/%d) |$t");
 	done < README.md > new
 	mv new README.md
+else
+	echo "siac: incumprimento pode já não existir (1)";
 fi


### PR DESCRIPTION
Imagens com alt text vazio não são por si incumprimentos. Podem indicar
imagens decorativas. No entanto, links cujo texto é apenas uma imagem
com alt text vazio.

Para implementar isto foi preciso dar algumas voltas, mas deixei
comentários no código a explicar o que se passa.

Closes #63 