### PR TITLE
Ignorar erros do html parser

### DIFF
--- a/scripts/01-parlamento.sh
+++ b/scripts/01-parlamento.sh
@@ -3,8 +3,8 @@
 # Incumprimentos: Vídeos disponibilizados em WMV, Canal Parlamento em Flash
 
 ## a) Vídeos disponibilizados em WMV
-wget http://www.parlamento.pt/ActividadeParlamentar/Paginas/DetalheAudiencia.aspx?BID=99371 -o /dev/null -O - | \
-	hxnormalize -x -l 10000 | grep "Links associados" -A 100 | \
+wget 'http://www.parlamento.pt/ActividadeParlamentar/Paginas/DetalheAudiencia.aspx?BID=99371' -o /dev/null -O - | \
+	hxnormalize -x -l 10000 2>/dev/null | grep "Links associados" -A 100 | \
 	grep "Bottom Fixed Nav" -B 100 | hxnormalize -x -l 10000|hxselect a -s '\n'|hxnormalize|grep href|cut -d\" -f2 > tmp
 
 a=$(diff tmp scripts/01/DetalheAudiencia.aspx?BID=99371 |wc -l)


### PR DESCRIPTION
Estes erros assustam qualquer um. Podemos ignorar 
```
running scripts/01-parlamento.sh
1579: syntax error
1604: syntax error
1641: syntax error
1666: syntax error
1715: syntax error
1768: syntax error
1805: syntax error
1826: syntax error
1853: syntax error
1886: syntax error
1937: syntax error
2026: syntax error
2059: syntax error
2121: syntax error
2186: syntax error
2203: syntax error
2230: syntax error
2275: syntax error
parlamento: incumprimento mantém-se, a actualizar README (faça um git diff, valide, e commit!)
```